### PR TITLE
undefined symbol: __cxa_pure_virtual

### DIFF
--- a/ext/leveldb/extconf.rb
+++ b/ext/leveldb/extconf.rb
@@ -5,6 +5,8 @@ Dir.chdir "../../leveldb"
 system "make libleveldb.a" or abort
 Dir.chdir "../ext/leveldb"
 
+CONFIG['LDSHARED'] = "$(CXX) -shared"
+
 $CFLAGS << " -I../../leveldb/include"
 $LIBS << " -L../../leveldb -lleveldb"
 create_makefile "leveldb/leveldb"


### PR DESCRIPTION
On ubuntu natty (amd64), leveldb installs fine but crashes on load:

```
irb(main):002:0> require 'rubygems'
=> true
irb(main):003:0> require 'leveldb'
LoadError: /home/gebner/.gem/ruby/1.8/gems/leveldb-ruby-0.5/lib/leveldb/leveldb.so: undefined symbol: __cxa_pure_virtual - /home/gebner/.gem/ruby/1.8/gems/leveldb-ruby-0.5/lib/leveldb/leveldb.so
        from /home/gebner/.gem/ruby/1.8/gems/leveldb-ruby-0.5/lib/leveldb/leveldb.so
        from /usr/lib/ruby/1.8/rubygems/custom_require.rb:31:in `require'
        from /home/gebner/.gem/ruby/1.8/gems/leveldb-ruby-0.5/lib/leveldb.rb:1
        from /usr/lib/ruby/1.8/rubygems/custom_require.rb:36:in `gem_original_require'
        from /usr/lib/ruby/1.8/rubygems/custom_require.rb:36:in `require'
        from (irb):3
        from (null):0
irb(main):004:0> %
```

I guess this is due to some linking changes in gcc 4.5.  The patch uses g++ instead of gcc to link the shared object and this seems to fix the problem.
