### PR TITLE
LevelDB::DB.{new,create,load} should coerce the pathname argument into a string

### DIFF
--- a/lib/leveldb.rb
+++ b/lib/leveldb.rb
@@ -8,19 +8,19 @@ class DB
     ## Loads or creates a LevelDB database as necessary, stored on disk at
     ## +pathname+.
     def new pathname
-      make pathname, true, false
+      make pathname.to_str, true, false
     end
 
     ## Creates a new LevelDB database stored on disk at +pathname+. Throws an
     ## exception if the database already exists.
     def create pathname
-      make pathname, true, true
+      make pathname.to_str, true, true
     end
 
     ## Loads a LevelDB database stored on disk at +pathname+. Throws an
     ## exception unless the database already exists.
     def load pathname
-      make pathname, false, false
+      make pathname.to_str, false, false
     end
   end
 

--- a/lib/leveldb.rb
+++ b/lib/leveldb.rb
@@ -8,20 +8,28 @@ class DB
     ## Loads or creates a LevelDB database as necessary, stored on disk at
     ## +pathname+.
     def new pathname
-      make pathname.to_str, true, false
+      make path_string(pathname), true, false
     end
 
     ## Creates a new LevelDB database stored on disk at +pathname+. Throws an
     ## exception if the database already exists.
     def create pathname
-      make pathname.to_str, true, true
+      make path_string(pathname), true, true
     end
 
     ## Loads a LevelDB database stored on disk at +pathname+. Throws an
     ## exception unless the database already exists.
     def load pathname
-      make pathname.to_str, false, false
+      make path_string(pathname), false, false
     end
+
+    private
+
+    ## Coerces the argument into a String for use as a filename/-path
+    def path_string pathname
+      File.respond_to?(:path) ? File.path(pathname) : pathname.to_str
+    end
+
   end
 
   alias :includes? :exists?


### PR DESCRIPTION
This patch is intended to match the behavior of `File.open` in order to be less surprising. `File.open` coerces the filename argument into a string before attempting to use it. This makes it possible to use the Pathname convenience-wrapper from the standard library.

Unfortunately, I'm not quite sure how File.open does it exactly, so this patch changes the type of exception LevelDB throws, while File.open will still throw a TypeError.

Before:

``` ruby
class Foo; end

LevelDB::DB.new(Foo)
# => TypeError: wrong argument type Class (expected String)

LevelDB::DB.new(Pathname.new('/tmp/foo'))
# => TypeError: wrong argument type Pathname (expected String)
```

After:

``` ruby
class Foo; end

LevelDB::DB.new(Foo)
# => NoMethodError: undefined method `to_str' on Foo (Class)

LevelDB::DB.new(Pathname.new('/tmp/foo'))
# => #<LevelDB::DB:0x6324 @pathname="/tmp/foo"> 
```
