### PR TITLE
Improve DB iteration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ ext/leveldb/libleveldb.a
 leveldb/libleveldb.a
 leveldb/leveldb.gyp
 pkg
+test/*.db

--- a/Rakefile
+++ b/Rakefile
@@ -26,4 +26,11 @@ end
 Gem::PackageTask.new spec do
 end
 
+require 'rake/testtask'
+Rake::TestTask.new(:test) do |test|
+  test.libs << 'lib' << 'test'
+  test.pattern = 'test/**/*_test.rb'
+  test.verbose = true
+end
+
 # vim: syntax=ruby

--- a/ext/leveldb/leveldb.cc
+++ b/ext/leveldb/leveldb.cc
@@ -68,7 +68,7 @@ static VALUE db_close(VALUE self) {
   return Qtrue;
 }
 
-static leveldb::ReadOptions db_readOptions(VALUE options) {
+static leveldb::ReadOptions parse_read_options(VALUE options) {
   leveldb::ReadOptions readOptions;
 
   if(!NIL_P(options)) {
@@ -82,7 +82,7 @@ static leveldb::ReadOptions db_readOptions(VALUE options) {
   return readOptions;
 }
 
-static leveldb::WriteOptions db_writeOptions(VALUE options) {
+static leveldb::WriteOptions parse_write_options(VALUE options) {
   leveldb::WriteOptions writeOptions;
 
   if(!NIL_P(options)) {
@@ -101,7 +101,7 @@ static VALUE db_get(int argc, VALUE* argv, VALUE self) {
   VALUE v_key, v_options;
   rb_scan_args(argc, argv, "11", &v_key, &v_options);
   Check_Type(v_key, T_STRING);
-  leveldb::ReadOptions readOptions = db_readOptions(v_options);
+  leveldb::ReadOptions readOptions = parse_read_options(v_options);
 
   bound_db* db;
   Data_Get_Struct(self, bound_db, db);
@@ -119,7 +119,7 @@ static VALUE db_delete(int argc, VALUE* argv, VALUE self) {
   VALUE v_key, v_options;
   rb_scan_args(argc, argv, "11", &v_key, &v_options);
   Check_Type(v_key, T_STRING);
-  leveldb::WriteOptions writeOptions = db_writeOptions(v_options);
+  leveldb::WriteOptions writeOptions = parse_write_options(v_options);
   leveldb::ReadOptions readOptions;
   readOptions.fill_cache = false;
 
@@ -158,7 +158,7 @@ static VALUE db_put(int argc, VALUE* argv, VALUE self) {
   rb_scan_args(argc, argv, "21", &v_key, &v_value, &v_options);
   Check_Type(v_key, T_STRING);
   Check_Type(v_value, T_STRING);
-  leveldb::WriteOptions writeOptions = db_writeOptions(v_options);
+  leveldb::WriteOptions writeOptions = parse_write_options(v_options);
 
   bound_db* db;
   Data_Get_Struct(self, bound_db, db);
@@ -306,7 +306,7 @@ static VALUE db_batch(int argc, VALUE* argv, VALUE self) {
 
   VALUE v_options;
   rb_scan_args(argc, argv, "01", &v_options);
-  leveldb::WriteOptions writeOptions = db_writeOptions(v_options);
+  leveldb::WriteOptions writeOptions = parse_write_options(v_options);
 
   leveldb::Status status = db->db->Write(writeOptions, &batch->batch);
   RAISE_ON_ERROR(status);

--- a/ext/leveldb/leveldb.cc
+++ b/ext/leveldb/leveldb.cc
@@ -142,15 +142,10 @@ static VALUE db_size(VALUE self) {
   return INT2NUM(count);
 }
 
-static VALUE db_each(int argc, VALUE* argv, VALUE self) {
+static VALUE db_iterate(VALUE self, VALUE key_from, VALUE key_to, bool reversed) {
   bound_db* db;
   Data_Get_Struct(self, bound_db, db);
   leveldb::Iterator* it = db->db->NewIterator(leveldb::ReadOptions());
-
-  VALUE key_from, key_to, reversed;
-  rb_scan_args(argc, argv, "03", &key_from, &key_to, &reversed);
-
-  reversed = NIL_P(reversed) ? false : true;
 
   if(NIL_P(key_from)) {
     if(reversed) {
@@ -194,6 +189,20 @@ static VALUE db_each(int argc, VALUE* argv, VALUE self) {
   return self;
 }
 
+static VALUE db_each(int argc, VALUE* argv, VALUE self) {
+  VALUE key_from, key_to;
+  rb_scan_args(argc, argv, "02", &key_from, &key_to);
+
+  return db_iterate(self, key_from, key_to, false);
+}
+
+static VALUE db_reverse_each(int argc, VALUE* argv, VALUE self) {
+  VALUE key_from, key_to;
+  rb_scan_args(argc, argv, "02", &key_from, &key_to);
+
+  return db_iterate(self, key_from, key_to, true);
+}
+
 static VALUE db_init(VALUE self, VALUE v_pathname) {
   rb_iv_set(self, "@pathname", v_pathname);
   return self;
@@ -213,6 +222,7 @@ void Init_leveldb() {
   rb_define_method(c_db, "close", (VALUE (*)(...))db_close, 0);
   rb_define_method(c_db, "size", (VALUE (*)(...))db_size, 0);
   rb_define_method(c_db, "each", (VALUE (*)(...))db_each, -1);
+  rb_define_method(c_db, "reverse_each", (VALUE (*)(...))db_reverse_each, -1);
 
   c_error = rb_define_class_under(m_leveldb, "Error", rb_eStandardError);
 }

--- a/ext/leveldb/leveldb.cc
+++ b/ext/leveldb/leveldb.cc
@@ -145,7 +145,9 @@ static VALUE db_size(VALUE self) {
 static VALUE db_iterate(VALUE self, VALUE key_from, VALUE key_to, bool reversed) {
   bound_db* db;
   Data_Get_Struct(self, bound_db, db);
-  leveldb::Iterator* it = db->db->NewIterator(leveldb::ReadOptions());
+  leveldb::ReadOptions readOptions;
+  readOptions.fill_cache = false;
+  leveldb::Iterator* it = db->db->NewIterator(readOptions);
   ID to_s = rb_intern("to_s");
 
   if(RTEST(key_from)) {

--- a/ext/leveldb/leveldb.cc
+++ b/ext/leveldb/leveldb.cc
@@ -167,19 +167,19 @@ static VALUE db_iterate(VALUE self, VALUE key_from, VALUE key_to, bool reversed)
 
   while(!passed_limit && it->Valid()) {
     leveldb::Slice key_sl = it->key();
-    VALUE key = SLICE_TO_RUBY_STRING(key_sl);
-    VALUE value = SLICE_TO_RUBY_STRING(it->value());
-    VALUE ary = rb_ary_new2(2);
-    rb_ary_push(ary, key);
-    rb_ary_push(ary, value);
-    rb_yield(ary);
 
     if(check_limit &&
-         (reversed ?
-            (key_sl.ToString() <= key_to_str) :
-            (key_sl.ToString() >= key_to_str))) {
+        (reversed ?
+          (key_sl.ToString() < key_to_str) :
+          (key_sl.ToString() > key_to_str))) {
       passed_limit = true;
     } else {
+      VALUE key = SLICE_TO_RUBY_STRING(key_sl);
+      VALUE value = SLICE_TO_RUBY_STRING(it->value());
+      VALUE ary = rb_ary_new2(2);
+      rb_ary_push(ary, key);
+      rb_ary_push(ary, value);
+      rb_yield(ary);
       reversed ? it->Prev() : it->Next();
     }
   }

--- a/ext/leveldb/leveldb.cc
+++ b/ext/leveldb/leveldb.cc
@@ -294,7 +294,7 @@ static VALUE batch_delete(VALUE self, VALUE v_key) {
   return Qtrue;
 }
 
-static VALUE db_batch(VALUE self) {
+static VALUE db_batch(int argc, VALUE* argv, VALUE self) {
   VALUE o_batch = batch_make(c_batch);
 
   rb_yield(o_batch);
@@ -304,7 +304,11 @@ static VALUE db_batch(VALUE self) {
   Data_Get_Struct(o_batch, bound_batch, batch);
   Data_Get_Struct(self, bound_db, db);
 
-  leveldb::Status status = db->db->Write(leveldb::WriteOptions(), &batch->batch);
+  VALUE v_options;
+  rb_scan_args(argc, argv, "01", &v_options);
+  leveldb::WriteOptions writeOptions = db_writeOptions(v_options);
+
+  leveldb::Status status = db->db->Write(writeOptions, &batch->batch);
   RAISE_ON_ERROR(status);
   return Qtrue;
 }
@@ -329,7 +333,7 @@ void Init_leveldb() {
   rb_define_method(c_db, "size", (VALUE (*)(...))db_size, 0);
   rb_define_method(c_db, "each", (VALUE (*)(...))db_each, -1);
   rb_define_method(c_db, "reverse_each", (VALUE (*)(...))db_reverse_each, -1);
-  rb_define_method(c_db, "batch", (VALUE (*)(...))db_batch, 0);
+  rb_define_method(c_db, "batch", (VALUE (*)(...))db_batch, -1);
 
   c_batch = rb_define_class_under(m_leveldb, "WriteBatch", rb_cObject);
   rb_define_singleton_method(c_batch, "make", (VALUE (*)(...))batch_make, 0);

--- a/ext/leveldb/leveldb.cc
+++ b/ext/leveldb/leveldb.cc
@@ -307,7 +307,7 @@ static VALUE db_batch(VALUE self) {
   Data_Get_Struct(self, bound_db, db);
 
   leveldb::Status status = db->db->Write(leveldb::WriteOptions(), &batch->batch);
-  batch_free(batch);
+
   if(status.ok()) {
     return Qtrue;
   } else {

--- a/ext/leveldb/leveldb.cc
+++ b/ext/leveldb/leveldb.cc
@@ -174,7 +174,9 @@ static VALUE db_size(VALUE self) {
 
   bound_db* db;
   Data_Get_Struct(self, bound_db, db);
-  leveldb::Iterator* it = db->db->NewIterator(leveldb::ReadOptions());
+  leveldb::ReadOptions readOptions;
+  readOptions.fill_cache = false;
+  leveldb::Iterator* it = db->db->NewIterator(readOptions);
 
   // apparently this is how we have to do it. slow and painful!
   for (it->SeekToFirst(); it->Valid(); it->Next()) count++;

--- a/lib/leveldb.rb
+++ b/lib/leveldb.rb
@@ -41,4 +41,10 @@ class DB
   def keys; map { |k, v| k } end
   def values; map { |k, v| v } end
 end
+
+class WriteBatch
+  class << self
+    private :new
+  end
+end
 end

--- a/test/db_test.rb
+++ b/test/db_test.rb
@@ -32,5 +32,18 @@ class DBTest < Test::Unit::TestCase
     assert DB.delete("test:async")
     assert DB.delete("test:sync", :sync => true)
   end
+
+  def test_batch
+    DB.put 'a', '1'
+    DB.put 'b', '1'
+
+    DB.batch do |b|
+      b.put 'a', 'batch'
+      b.delete 'b'
+    end
+
+    assert_equal 'batch', DB.get('a')
+    assert_nil DB.get('b')
+  end
 end
 

--- a/test/db_test.rb
+++ b/test/db_test.rb
@@ -7,12 +7,30 @@ class DBTest < Test::Unit::TestCase
   FileUtils.rm_rf path
   DB = LevelDB::DB.new(path)
 
+  def test_get
+    DB.put 'test:read', '1'
+
+    assert_equal '1', DB.get('test:read')
+    assert_equal '1', DB.get('test:read', :fill_cache => false)
+    assert_equal '1', DB.get('test:read',
+                             :fill_cache => false,
+                             :verify_checksums => true)
+  end
+
   def test_put
     DB.put "test:async", "1"
     DB.put "test:sync", "1", :sync => true
 
     assert_equal "1", DB.get("test:async")
     assert_equal "1", DB.get("test:sync")
+  end
+
+  def test_delete
+    DB.put 'test:async', '1'
+    DB.put 'test:sync', '1'
+
+    assert DB.delete("test:async")
+    assert DB.delete("test:sync", :sync => true)
   end
 end
 

--- a/test/db_test.rb
+++ b/test/db_test.rb
@@ -1,0 +1,18 @@
+require 'test/unit'
+require File.expand_path("../../lib/leveldb", __FILE__)
+require 'fileutils'
+
+class DBTest < Test::Unit::TestCase
+  path = File.expand_path("../db_test.db", __FILE__)
+  FileUtils.rm_rf path
+  DB = LevelDB::DB.new(path)
+
+  def test_put
+    DB.put "test:async", "1"
+    DB.put "test:sync", "1", :sync => true
+
+    assert_equal "1", DB.get("test:async")
+    assert_equal "1", DB.get("test:sync")
+  end
+end
+

--- a/test/db_test.rb
+++ b/test/db_test.rb
@@ -44,6 +44,14 @@ class DBTest < Test::Unit::TestCase
 
     assert_equal 'batch', DB.get('a')
     assert_nil DB.get('b')
+
+    DB.batch :sync => true do |b|
+      b.put 'b', 'batch'
+      b.delete 'a'
+    end
+
+    assert_equal 'batch', DB.get('b')
+    assert_nil DB.get('a')
   end
 end
 

--- a/test/iteration_test.rb
+++ b/test/iteration_test.rb
@@ -30,7 +30,7 @@ class IterationTest < Test::Unit::TestCase
   end
 
   def test_each_with_key_from_to
-    expected = %w(b/1 b/2 b/3 c/1)
+    expected = %w(b/1 b/2 b/3)
     keys = []
     DB.each('b', 'b/4') do |key, value|
       keys << key
@@ -60,7 +60,7 @@ class IterationTest < Test::Unit::TestCase
   end
 
   def test_reverse_each_with_key_from_to
-    expected = %w(c/1 b/3 b/2 b/1 a/1)
+    expected = %w(c/1 b/3 b/2 b/1)
     keys = []
     DB.reverse_each('c', 'b') do |key, value|
       keys << key

--- a/test/iteration_test.rb
+++ b/test/iteration_test.rb
@@ -1,0 +1,72 @@
+require 'test/unit'
+require File.expand_path("../../lib/leveldb", __FILE__)
+
+class IterationTest < Test::Unit::TestCase
+  DB = LevelDB::DB.new(File.expand_path("../iteration.db", __FILE__))
+  DB.put "a/1", "1"
+  DB.put "b/1", "1"
+  DB.put "b/2", "1"
+  DB.put "b/3", "1"
+  DB.put "c/1", "1"
+
+  def test_each
+    expected = %w(a/1 b/1 b/2 b/3 c/1)
+    keys = []
+    DB.each do |key, value|
+      keys << key
+    end
+
+    assert_equal expected, keys
+  end
+
+  def test_each_with_key_from
+    expected = %w(b/1 b/2 b/3 c/1)
+    keys = []
+    DB.each('b') do |key, value|
+      keys << key
+    end
+
+    assert_equal expected, keys
+  end
+
+  def test_each_with_key_from_to
+    expected = %w(b/1 b/2 b/3 c/1)
+    keys = []
+    DB.each('b', 'b/4') do |key, value|
+      keys << key
+    end
+
+    assert_equal expected, keys
+  end
+
+  def test_reverse_each
+    expected = %w(c/1 b/3 b/2 b/1 a/1)
+    keys = []
+    DB.reverse_each do |key, value|
+      keys << key
+    end
+
+    assert_equal expected, keys
+  end
+
+  def test_reverse_each_with_key_from
+    expected = %w(b/1 a/1)
+    keys = []
+    DB.reverse_each('b') do |key, value|
+      keys << key
+    end
+
+    assert_equal expected, keys
+  end
+
+  def test_reverse_each_with_key_from_to
+    expected = %w(c/1 b/3 b/2 b/1 a/1)
+    keys = []
+    DB.reverse_each('c', 'b') do |key, value|
+      keys << key
+    end
+
+    assert_equal expected, keys
+  end
+end
+


### PR DESCRIPTION
I wanted a few things:
- Specify a start key for iteration.
- Specify an end key.
- Iterate in reverse.

``` ruby
# assume keys a, b, c
db.each('b') { |k, v| puts k }
# b
# c

db.each('a', 'b') { |k, v| puts k }
# a
# b

db.reverse_each('b') { |k, v| puts k }
# b
# a

db.reverse_each('c', 'b') { |k, v| puts k }
# c
# b
```

This is my first c++ code.
