### PR TITLE
fix compilation in rubinius/osx.  still works with 1.8.7 and 1.9.3

### DIFF
--- a/ext/leveldb/extconf.rb
+++ b/ext/leveldb/extconf.rb
@@ -5,14 +5,9 @@ Dir.chdir "../../leveldb"
 system "make libleveldb.a" or abort
 Dir.chdir "../ext/leveldb"
 
-CONFIG['LDSHARED'] = "$(CXX) -shared"
+CONFIG['LDSHARED'] = CONFIG['LDSHARED'].sub('$(CC)', '$(CXX)').sub('gcc','g++')
 
 $CFLAGS << " -I../../leveldb/include"
 $LIBS << " -L../../leveldb -lleveldb"
-if RUBY_PLATFORM =~ /darwin/
-  $CFLAGS.sub! "-arch i386", ""
-  $LDFLAGS.sub! "-arch i386", ""
-  $LIBS << " -lruby" # whyyyyy
-end
 
 create_makefile "leveldb/leveldb"


### PR DESCRIPTION
I couldn't get this to compile in Rubinius because of the `$LIBS << ' -lruby'` line.  I got this diff from @tmm1, and I can now generate and install this gem on ruby 1.8.7, ruby 1.9.3, and rbx 2.0 (all on osx).  I'm told this should work for linux also.

Also, I had to make this gemspec tweak to get it to build in 1.9.3:

```
-s.date = Time.now.to_s
+s.date = Time.now
```
