### PR TITLE
Create a custom Enumerator

### DIFF
--- a/lib/leveldb.rb
+++ b/lib/leveldb.rb
@@ -1,50 +1,50 @@
 require 'leveldb/leveldb' # the c extension
 
 module LevelDB
-class DB
-  include Enumerable
-  class << self
+  class DB
+    include Enumerable
+    class << self
 
-    ## Loads or creates a LevelDB database as necessary, stored on disk at
-    ## +pathname+.
-    def new pathname
-      make path_string(pathname), true, false
+      ## Loads or creates a LevelDB database as necessary, stored on disk at
+      ## +pathname+.
+      def new pathname
+        make path_string(pathname), true, false
+      end
+
+      ## Creates a new LevelDB database stored on disk at +pathname+. Throws an
+      ## exception if the database already exists.
+      def create pathname
+        make path_string(pathname), true, true
+      end
+
+      ## Loads a LevelDB database stored on disk at +pathname+. Throws an
+      ## exception unless the database already exists.
+      def load pathname
+        make path_string(pathname), false, false
+      end
+
+      private
+
+      ## Coerces the argument into a String for use as a filename/-path
+      def path_string pathname
+        File.respond_to?(:path) ? File.path(pathname) : pathname.to_str
+      end
+
     end
 
-    ## Creates a new LevelDB database stored on disk at +pathname+. Throws an
-    ## exception if the database already exists.
-    def create pathname
-      make path_string(pathname), true, true
-    end
+    alias :includes? :exists?
+    alias :contains? :exists?
+    alias :member? :exists?
+    alias :[] :get
+    alias :[]= :put
 
-    ## Loads a LevelDB database stored on disk at +pathname+. Throws an
-    ## exception unless the database already exists.
-    def load pathname
-      make path_string(pathname), false, false
-    end
-
-    private
-
-    ## Coerces the argument into a String for use as a filename/-path
-    def path_string pathname
-      File.respond_to?(:path) ? File.path(pathname) : pathname.to_str
-    end
-
+    def keys; map { |k, v| k } end
+    def values; map { |k, v| v } end
   end
 
-  alias :includes? :exists?
-  alias :contains? :exists?
-  alias :member? :exists?
-  alias :[] :get
-  alias :[]= :put
-
-  def keys; map { |k, v| k } end
-  def values; map { |k, v| v } end
-end
-
-class WriteBatch
-  class << self
-    private :new
+  class WriteBatch
+    class << self
+      private :new
+    end
   end
-end
 end

--- a/lib/leveldb.rb
+++ b/lib/leveldb.rb
@@ -39,6 +39,14 @@ module LevelDB
     alias :[] :get
     alias :[]= :put
 
+    def each(*args)
+      iterator = Iterator.new(self, *args)
+      if block_given?
+        iterator.each &Proc.new
+      end
+      iterator
+    end
+
     def keys; map { |k, v| k } end
     def values; map { |k, v| v } end
 
@@ -48,6 +56,8 @@ module LevelDB
   end
 
   class Iterator
+    include Enumerable
+
     attr_reader :db, :from, :to
 
     def self.new(db, options = nil)

--- a/lib/leveldb.rb
+++ b/lib/leveldb.rb
@@ -29,8 +29,9 @@ module LevelDB
       def path_string pathname
         File.respond_to?(:path) ? File.path(pathname) : pathname.to_str
       end
-
     end
+
+    attr_reader :pathname
 
     alias :includes? :exists?
     alias :contains? :exists?
@@ -40,6 +41,22 @@ module LevelDB
 
     def keys; map { |k, v| k } end
     def values; map { |k, v| v } end
+
+    def inspect
+      %(<#{self.class} #{@pathname.inspect}>)
+    end
+  end
+
+  class Iterator
+    attr_reader :db, :from, :to
+
+    def reversed?
+      !!@reversed
+    end
+
+    def inspect
+      %(<#{self.class} #{@db.inspect} @from=#{@from.inspect} @to=#{@to.inspect}#{' (reversed)' if @reversed}>)
+    end
   end
 
   class WriteBatch

--- a/lib/leveldb.rb
+++ b/lib/leveldb.rb
@@ -50,6 +50,10 @@ module LevelDB
   class Iterator
     attr_reader :db, :from, :to
 
+    def self.new(db, options = nil)
+      make(db, options || {})
+    end
+
     def reversed?
       !!@reversed
     end

--- a/test/iteration_test.rb
+++ b/test/iteration_test.rb
@@ -22,7 +22,7 @@ class IterationTest < Test::Unit::TestCase
   def test_each_with_key_from
     expected = %w(b/1 b/2 b/3 c/1)
     keys = []
-    DB.each('b') do |key, value|
+    DB.each(:from => 'b') do |key, value|
       keys << key
     end
 
@@ -32,7 +32,7 @@ class IterationTest < Test::Unit::TestCase
   def test_each_with_key_from_to
     expected = %w(b/1 b/2 b/3)
     keys = []
-    DB.each('b', 'b/4') do |key, value|
+    DB.each(:from => 'b', :to => 'b/4') do |key, value|
       keys << key
     end
 
@@ -42,7 +42,7 @@ class IterationTest < Test::Unit::TestCase
   def test_reverse_each
     expected = %w(c/1 b/3 b/2 b/1 a/1)
     keys = []
-    DB.reverse_each do |key, value|
+    DB.each(:reversed => true) do |key, value|
       keys << key
     end
 
@@ -52,7 +52,7 @@ class IterationTest < Test::Unit::TestCase
   def test_reverse_each_with_key_from
     expected = %w(b/1 a/1)
     keys = []
-    DB.reverse_each('b') do |key, value|
+    DB.each(:from => 'b', :reversed => true) do |key, value|
       keys << key
     end
 
@@ -62,7 +62,7 @@ class IterationTest < Test::Unit::TestCase
   def test_reverse_each_with_key_from_to
     expected = %w(c/1 b/3 b/2 b/1)
     keys = []
-    DB.reverse_each('c', 'b') do |key, value|
+    DB.each(:from => 'c', :to => 'b', :reversed => true) do |key, value|
       keys << key
     end
 

--- a/test/iteration_test.rb
+++ b/test/iteration_test.rb
@@ -68,5 +68,33 @@ class IterationTest < Test::Unit::TestCase
 
     assert_equal expected, keys
   end
+
+  def test_iterator_init_with_default_options
+    iter = LevelDB::Iterator.new DB
+    assert_equal DB, iter.db
+    assert_nil iter.from
+    assert_nil iter.to
+    assert_equal false, iter.reversed?
+  end
+
+  def test_iterator_init_with_options
+    iter = LevelDB::Iterator.new DB, :from => 'abc', :to => 'def', :reversed => true
+    assert_equal DB,iter.db
+    assert_equal 'abc', iter.from
+    assert_equal 'def', iter.to
+    assert_equal true, iter.reversed?
+  end
+
+  def test_iterator_init_with_no_args
+    assert_raise ArgumentError do
+      LevelDB::Iterator.new
+    end
+  end
+
+  def test_iterator_requires_db
+    assert_raise ArgumentError do
+      LevelDB::Iterator.new 'db'
+    end
+  end
 end
 

--- a/test/iteration_test.rb
+++ b/test/iteration_test.rb
@@ -4,10 +4,10 @@ require File.expand_path("../../lib/leveldb", __FILE__)
 class IterationTest < Test::Unit::TestCase
   DB = LevelDB::DB.new(File.expand_path("../iteration.db", __FILE__))
   DB.put "a/1", "1"
-  DB.put "b/1", "1"
-  DB.put "b/2", "1"
-  DB.put "b/3", "1"
-  DB.put "c/1", "1"
+  DB.put "b/1", "2"
+  DB.put "b/2", "3"
+  DB.put "b/3", "4"
+  DB.put "c/1", "5"
 
   def test_each
     expected = %w(a/1 b/1 b/2 b/3 c/1)
@@ -67,6 +67,45 @@ class IterationTest < Test::Unit::TestCase
     end
 
     assert_equal expected, keys
+  end
+
+  def test_iterator_reverse_each_with_key_from_to
+    expected_keys = %w(c/1 b/3 b/2 b/1)
+    expected_values = %w(5 4 3 2)
+    keys = []
+    values = []
+
+    iter = LevelDB::Iterator.new DB, :from => 'c', :to => 'b', :reversed => true
+    iter.each do |key, value|
+      keys << key
+      values << value
+    end
+
+    assert_equal expected_keys, keys
+    assert_equal expected_values, values
+  end
+
+  def test_iterator_each
+    expected_keys = %w(a/1 b/1 b/2 b/3 c/1)
+    expected_values = %w(1 2 3 4 5)
+    keys = []
+    values = []
+    iter = LevelDB::Iterator.new DB
+    iter.each do |key, value|
+      keys << key
+      values << value
+    end
+
+    assert_equal expected_keys, keys
+    assert_equal expected_values, values
+  end
+
+  def test_iterator_peek
+    iter = LevelDB::Iterator.new DB
+    assert_equal %w(a/1 1), iter.peek, iter.invalid_reason
+    assert_equal %w(a/1 1), iter.peek, iter.invalid_reason
+    assert_nil iter.scan
+    assert_equal %w(b/1 2), iter.peek, iter.invalid_reason
   end
 
   def test_iterator_init_with_default_options


### PR DESCRIPTION
`#each` should return an enumerator so that you can call other Enumerable methods on a subset of the LevelDB values.  We'll need a custom enumerator that wraps the LevelDB Iterator properly.  We don't want to load all keys into memory or anything like that.
