### PR TITLE
Fix memory leak in iterator free function.

### DIFF
--- a/ext/leveldb/leveldb.cc
+++ b/ext/leveldb/leveldb.cc
@@ -405,6 +405,8 @@ typedef struct current_iteration {
 } current_iteration;
 
 static void current_iteration_free(current_iteration* iter) {
+  delete iter->iterator;
+  iter->iterator = NULL;
   delete iter;
 }
 


### PR DESCRIPTION
Without this fix, I could get LevelDB to leak memory easily by repeatedly creating and disposing of a partially consumed iterator, eg:

``` ruby
require 'securerandom'
require 'leveldb'

db = LevelDB::DB.new '/tmp/leak-test.%s' % [SecureRandom.hex]

1000.times { db.put SecureRandom.hex, SecureRandom.hex }

1000_000.times { db.to_enum.take(1) }
```
