### PR TITLE
Require fails with bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "http://rubygems.org"
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,20 @@
+PATH
+  remote: .
+  specs:
+    leveldb-ruby (0.15.1)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    json (1.7.7)
+    rake (10.0.4)
+    rdoc (4.0.1)
+      json (~> 1.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  leveldb-ruby!
+  rake
+  rdoc

--- a/Rakefile
+++ b/Rakefile
@@ -1,41 +1,28 @@
 require 'rubygems'
 require 'rubygems/package_task'
-require 'find'
+require 'rake/testtask'
 
-spec = Gem::Specification.new do |s|
- s.name = "leveldb-ruby"
- s.version = "0.15"
- s.date = Time.now
- s.email = "wmorgan-leveldb-ruby-gemspec@masanjin.net"
- s.authors = ["William Morgan"]
- s.summary = "a Ruby binding to LevelDB"
- s.homepage = "http://github.com/wmorgan/leveldb-ruby"
- s.files = %w(README LICENSE ext/leveldb/extconf.rb ext/leveldb/platform.rb lib/leveldb.rb ext/leveldb/leveldb.cc leveldb/Makefile leveldb/build_detect_platform)
- Find.find("leveldb") { |x| s.files += [x] if x =~ /\.(cc|h)$/}
- s.extensions = %w(ext/leveldb/extconf.rb)
- s.executables = []
- s.extra_rdoc_files = %w(README ext/leveldb/leveldb.cc)
- s.rdoc_options = %w(-c utf8 --main README --title LevelDB)
- s.description = "LevelDB-Ruby is a Ruby binding to LevelDB."
- s.require_paths = ["lib", "ext"]
-end
-
+desc "Build the docs"
 task :rdoc do |t|
   sh "rm -rf doc; rdoc #{spec.rdoc_options.join(' ')} #{spec.extra_rdoc_files.join(' ')} lib/leveldb.rb"
 end
 
+spec = eval File.read(File.expand_path("../leveldb-ruby.gemspec", __FILE__))
 Gem::PackageTask.new spec do
 end
 
-require 'rake/testtask'
-Rake::TestTask.new(:test) do |test|
+Rake::TestTask.new(:test => :build) do |test|
   test.libs << 'ext' << 'test'
   test.pattern = 'test/**/*_test.rb'
   test.verbose = true
 end
 
+desc "Build the extension"
 task :build do |t|
   sh "cd ext/leveldb && ruby extconf.rb && make"
 end
+
+desc "Default task"
+task :default => :test
 
 # vim: syntax=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,7 @@ spec = Gem::Specification.new do |s|
  s.extra_rdoc_files = %w(README ext/leveldb/leveldb.cc)
  s.rdoc_options = %w(-c utf8 --main README --title LevelDB)
  s.description = "LevelDB-Ruby is a Ruby binding to LevelDB."
+ s.require_paths = ["lib", "ext"]
 end
 
 task :rdoc do |t|

--- a/leveldb-ruby.gemspec
+++ b/leveldb-ruby.gemspec
@@ -1,0 +1,24 @@
+# -*- encoding: utf-8 -*-
+
+Gem::Specification.new do |s|
+  s.name        = "leveldb-ruby"
+  s.version     = "0.15.1"
+  s.platform    = Gem::Platform::RUBY
+  s.licenses    = ["MIT"]
+  s.summary     = "a Ruby binding to LevelDB"
+  s.email       = "wmorgan-leveldb-ruby-gemspec@masanjin.net"
+  s.homepage    = "http://github.com/wmorgan/leveldb-ruby"
+  s.description = "LevelDB-Ruby is a Ruby binding to LevelDB."
+  s.authors     = ["William Morgan"]
+  s.extensions  = %w(ext/leveldb/extconf.rb)
+
+  s.files         = `git ls-files`.split("\n")
+  s.test_files    = `git ls-files -- test/*`.split("\n")
+  s.require_paths = ["lib", "ext"]
+  s.extra_rdoc_files = %w(README ext/leveldb/leveldb.cc)
+  s.rdoc_options  = %w(-c utf8 --main README --title LevelDB)
+
+  s.add_development_dependency("rake")
+  s.add_development_dependency("rdoc")
+end
+


### PR DESCRIPTION
We cam across problems when the gem was used within a bundle:

```
require 'leveldb'
# -> /home/.../gems/leveldb-ruby-0.15/lib/leveldb.rb:1:in `require': cannot load such file -- leveldb/leveldb (LoadError)
```

The patch above solves the issue
