### PR TITLE
Support for Ruby 2.0 >= p195

### DIFF
--- a/ext/leveldb/extconf.rb
+++ b/ext/leveldb/extconf.rb
@@ -9,6 +9,8 @@ Dir.chdir "../ext/leveldb"
 set_platform_specific_variables!
 
 $CFLAGS << " -I../../leveldb/include"
+$CPPFLAGS << " -I../../leveldb/include"
+
 $LIBS << " -L../../leveldb -lleveldb"
 
 create_makefile "leveldb/leveldb"


### PR DESCRIPTION
It looks like CFLAGS stopped being added to the CXXFLAGS.
This should still be fine for 1.9 and 1.8 (as far as my testing can tell), but I can make this change 2.0 specific if you'd like.

Commit in ruby: https://github.com/ruby/ruby/commit/2e26edb633606f1e99d22817678e11c25f7d2882
